### PR TITLE
Disable PDF generation, closes #25

### DIFF
--- a/docet-core/pom.xml
+++ b/docet-core/pom.xml
@@ -86,11 +86,13 @@
             <groupId>com.itextpdf</groupId>
             <artifactId>itextpdf</artifactId>
             <version>${libs.itext}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.itextpdf.tool</groupId>
             <artifactId>xmlworker</artifactId>
             <version>${libs.itext}</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 </project>

--- a/docet-core/src/main/java/docet/SimplePackageLocator.java
+++ b/docet-core/src/main/java/docet/SimplePackageLocator.java
@@ -17,7 +17,6 @@
 package docet;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -37,13 +36,13 @@ public class SimplePackageLocator implements DocetPackageLocator {
     private final Map<String, DocetPackageLocation> installedPackages;
     private final DocetConfiguration docetConf;
 
-    public SimplePackageLocator(final DocetConfiguration docetConf) throws IOException {
+    public SimplePackageLocator(final DocetConfiguration docetConf) {
         this.docetConf = docetConf;
         this.installedPackages = new HashMap<>();
         this.initializeInstalledPackages();
     }
 
-    private void initializeInstalledPackages() throws IOException {
+    private void initializeInstalledPackages() {
         //only in case we are in developer mode then load packages at startup
         final Set<String> availablePackages = this.docetConf.getInstalledPackages();
         if (!availablePackages.isEmpty()) {


### PR DESCRIPTION
Added `docet.pdf.enable.generation` property to disable pdf generation (default to `true`: pdf generation enabled).

When disabled pdf generation libraries can be safely removed from maven build:
```
            <dependency>
                <groupId>org.docetproject</groupId>
                <artifactId>docet-core</artifactId>
                <version>${docet.version}</version>
                <!-- Avoid itext AGPL v3 dependency -->
                <exclusions>
                    <exclusion>
                        <groupId>com.itextpdf</groupId>
                        <artifactId>itextpdf</artifactId>
                    </exclusion>
                    <exclusion>
                        <groupId>com.itextpdf.tool</groupId>
                        <artifactId>xmlworker</artifactId>
                    </exclusion>
                </exclusions>
            </dependency>
```