### PR TITLE
Implementation to redirect to a FAQ page in /faq

### DIFF
--- a/docet-core/src/main/java/docet/engine/DocetManager.java
+++ b/docet-core/src/main/java/docet/engine/DocetManager.java
@@ -278,16 +278,21 @@ public final class DocetManager {
         String res = "";
         try {
             final Document htmlDoc = parsePageForPackage(packageName, pageId, lang, format, faq, params, ctx);
-            if (format == DocetDocFormat.TYPE_HTML) {
-                html.append(htmlDoc.body().getElementsByTag("div").first().html());
-                html.append(generateFooter(lang, packageName, pageId));
-                res = DocetUtils.cleanPageText(html.toString());
-            } else if (format == DocetDocFormat.TYPE_PDF) {
-                htmlDoc.outputSettings().prettyPrint(false);
-                html.append(htmlDoc.html());
-                res = DocetUtils.cleanPageText(html.toString());
-            } else {
+            if (null == format) {
                 throw new DocetException(DocetException.CODE_GENERIC_ERROR, "Page format not supported for page " + pageId + " package " + packageName);
+            } else switch (format) {
+                case TYPE_HTML:
+                    html.append(htmlDoc.body().getElementsByTag("div").first().html());
+                    html.append(generateFooter(lang, packageName, pageId, faq));
+                    res = DocetUtils.cleanPageText(html.toString());
+                    break;
+                case TYPE_PDF:
+                    htmlDoc.outputSettings().prettyPrint(false);
+                    html.append(htmlDoc.html());
+                    res = DocetUtils.cleanPageText(html.toString());
+                    break;
+                default:
+                    throw new DocetException(DocetException.CODE_GENERIC_ERROR, "Page format not supported for page " + pageId + " package " + packageName);
             }
         } catch (IOException ex) {
             throw new DocetException(DocetException.CODE_RESOURCE_NOTFOUND, "Error on retrieving page '" + pageId + "' for package '" + packageName + "'", ex);
@@ -331,9 +336,9 @@ public final class DocetManager {
         return docPage;
     }
 
-    private String generateFooter(final String lang, final String packageId, final String pageId) {
+    private String generateFooter(final String lang, final String packageId, final String pageId, final boolean faq) {
         String res = "";
-        res += "<div class='docet-page-info docet-page-info-hidden'>" + packageId + ":" + pageId + "</div>";
+        res += "<div class='docet-page-info docet-page-info-hidden'>" + packageId + ":" + pageId + ":" + faq + "</div>";
         if (docetConf.isDebugMode()) {
             res += "<div class='docet-debug-info'>";
             final String debugInfo = "Docet " + docetConf.getVersion() + " | Language: " + lang;

--- a/docet-core/src/main/resources/META-INF/resources/docetres/docet/docet.js
+++ b/docet-core/src/main/resources/META-INF/resources/docetres/docet/docet.js
@@ -16,6 +16,7 @@ var Docet = (function ($, document) {
             toc: "/toc",
             packagelist: "/package",
             pages: "/pages",
+            faq: "/faq",
             pdfs: "/pdfs"
         },
         search: {
@@ -199,9 +200,11 @@ var Docet = (function ($, document) {
             var tokens = pageInfoContent.split(":");
             var packageId = tokens[0];
             var pageId = tokens[1];
+            var faq = tokens[2];
             if (packageId && pageId) {
                 result.packageId = packageId;
                 result.pageId = pageId;
+                result.faq = faq;
             }
         }
 
@@ -890,7 +893,7 @@ var Docet = (function ($, document) {
         window.open(pdfurl + additionalQueryStr, '_blank', '');
     }
 
-    var jumpToPage = function (packageId, pageId, tocHidden, searchHidden) {
+    var jumpToPage = function (packageId, pageId, requestType, tocHidden, searchHidden) {
         if (tocHidden) {
             hideToc();
         }
@@ -901,7 +904,7 @@ var Docet = (function ($, document) {
         setCurrentPackage(packageId);
         loadTocTreeForPackage(pageId, packageId, !tocHidden);
         $.ajax({
-            url: getBaseURL() + docet.urls.pages + '/' + packageId + '/' + pageId + '.mndoc',
+            url: getBaseURL() + requestType + '/' + packageId + '/' + pageId + '.mndoc',
             data: mergeData({}),
             async: true,
             method: 'GET',
@@ -959,7 +962,21 @@ var Docet = (function ($, document) {
             hideSearch = arguments[3];
         }
         pageId = pageId + "_" + docet.localization.language;
-        jumpToPage(packageId, pageId, hideToc, hideSearch);
+        jumpToPage(packageId, pageId, docet.urls.pages, hideToc, hideSearch);
+    };
+    
+    res.jumpToFaqPage = function (packageId, pageId) {
+        var hideToc = false;
+        var hideSearch = false;
+
+        if (arguments.length == 3) {
+            hideToc = arguments[2];
+        }
+        if (arguments.length == 4) {
+            hideSearch = arguments[3];
+        }
+        pageId = pageId + "_" + docet.localization.language;
+        jumpToPage(packageId, pageId, docet.urls.faq, hideToc, hideSearch);
     };
 
     res.jumpToPdf = function (packageId, pdfId) {

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
             <name>Matteo Casadei</name>
             <organization>Diennea</organization>
         </developer>
+        <developer>
+            <id>mino181295</id>
+            <name>Matteo Minardi</name>
+            <organization>Diennea</organization>
+        </developer>
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Now with Docet.jumpToFaqPage(packageId, pageId) you can go to a FAQ page with a special request to /faq with the same logic of jumpToPage.

In the notifyPageChanged you can find in the currentPageInfo the FAQ flag to know if the new page is Normal or FAQ