### PR TITLE
Fix missing parameter keys encoding

### DIFF
--- a/docet-core/src/main/java/docet/engine/DocetManager.java
+++ b/docet-core/src/main/java/docet/engine/DocetManager.java
@@ -688,7 +688,7 @@ public final class DocetManager {
             params.entrySet().stream().filter(entry -> !"id".equals(entry.getKey()) && !"lang".equals(entry.getKey()))
                 .forEach(entry -> {
                     try {
-                        tmpUrl.setValue(tmpUrl.getValue() + entry.getKey()
+                        tmpUrl.setValue(tmpUrl.getValue() + URLEncoder.encode(entry.getKey(), ENCODING_UTF_8.name())
                             + "=" + URLEncoder.encode(entry.getValue()[0], ENCODING_UTF_8.name()) + "&");
                     } catch (UnsupportedEncodingException impossibile) {
                         LOGGER.log(Level.SEVERE, "impossible to encode param {0}", impossibile);
@@ -701,6 +701,7 @@ public final class DocetManager {
                 parsedUrl = tmpUrlValue.substring(0, tmpUrlValue.lastIndexOf('&'));
             }
         }
+
         return parsedUrl;
     }
 


### PR DESCRIPTION
On last Tomcat version there is an error when accessing search result:

`java.lang.IllegalArgumentException: Invalid character found in the request target. The valid characters are defined in RFC 7230 and RFC 3986`

It happens because returned urls contains unescaped characters (**[]**):

`{"status":0,"errorCode":"","errorMessage":"","results":[{"items":[{"packageId":"technical-guide","pageId":"rblBlacklist_en","pageLink":"docs/pages/technical-guide/rblBlacklist_en.mndoc?enablePkg[]=quickstart","langua...`

This PR add escaping on parameters names too (it was already inplace for values)