### PR TITLE
Introduce a feature to skip a single page TOC validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: java
+sudo: false
+
+cache:
+  directories:
+  - "$HOME/.m2"
+
+jobs:
+  include:
+  - stage: test
+    jdk: openjdk11
+    script: mvn verify -Pjenkins -Dmaven.test.redirectTestOutputToFile=true
+
+branches:
+  only:
+  - master

--- a/docet-sample-doc/src/main/docs/descriptor.html
+++ b/docet-sample-doc/src/main/docs/descriptor.html
@@ -1,16 +1,16 @@
 <html>
-<body>
-<div lang="it">
-<h1>Guida di esempio</h1>
-<p>
-Pacchetto di esempio Docet. 
-</p>
-</div>
-<div lang="en">
-<h1>Sample Guide</h1>
-<p>
-A sample guide to show how to easy create your guide with Docet.
-</p>
-</div>
-</body>
+    <body>
+        <div lang="it">
+            <h1>Guida di esempio</h1>
+            <p>
+                Pacchetto di esempio Docet. 
+            </p>
+        </div>
+        <div lang="en">
+            <h1>Sample Guide</h1>
+            <p>
+                A sample guide to show how to easy create your guide with Docet.
+            </p>
+        </div>
+    </body>
 </html>

--- a/docet-sample-doc/src/main/docs/en/pages/hidden.html
+++ b/docet-sample-doc/src/main/docs/en/pages/hidden.html
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
+        <meta name="docet-hidden-page" >
+    </head>
+    <body>
+        <div id="main">
+            <h1>Page Hidden</h1>
+            <p id="abstract">
+                This page is not linked in the table of content and it can be accessed only via link.
+            </p>
+        </div>
+    </body>
+</html>

--- a/docet-sample-doc/src/main/docs/en/pages/main.html
+++ b/docet-sample-doc/src/main/docs/en/pages/main.html
@@ -1,20 +1,24 @@
 <html>
-<head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	
-</head>
-<body><div id="main">
-<h1>Sample Documentation Package</h1>
-<p id="abstract">A simple documentation package to show how to build comprehensive guides via simple but powerful Docet language.</p>
-<p>
-This is a sample documentation package to show you how easy it is to build comprehensive guides by using simple but powerful Docet language. <br />
-Docet easy-to-integrate framework will do the rest, by providing <i>a fast way to integrate</i> documentation packages such as this one, <i>into your Java Web application</i>.
-</p>
-<div class="msg note"> <strong>Note</strong><br />
-    For an example on how integrate Docet into your Java Web app, please have a look at project <b>docet-sample-app</b> </div>
-
-<div class="related">
-    <strong>Next item:</strong>
-    <p><a href="sd001.html">Sample Document </a></p>
-</div>
-</div></body></html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    </head>
+    <body>
+        <div id="main">
+            <h1>Sample Documentation Package</h1>
+            <p id="abstract">
+                A simple documentation package to show how to build comprehensive guides via simple but powerful Docet language.
+            </p>
+            <p>
+                This is a sample documentation package to show you how easy it is to build comprehensive guides by using simple but powerful Docet language. <br />
+                Docet easy-to-integrate framework will do the rest, by providing <i>a fast way to integrate</i> documentation packages such as this one, <i>into your Java Web application</i>.
+            </p>
+            <div class="msg note"> <strong>Note</strong><br />
+                For an example on how integrate Docet into your Java Web app, please have a look at project <b>docet-sample-app</b> 
+            </div>
+            <div class="related">
+                <strong>Next item:</strong>
+                <p><a href="sd001.html">Sample Document </a></p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docet-sample-doc/src/main/docs/en/toc.html
+++ b/docet-sample-doc/src/main/docs/en/toc.html
@@ -1,29 +1,30 @@
 <html>
-<head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<title></title>
-	
-</head>
-<body>
-<nav id="docet-menu">
-<ul>
-    <li><a href="sd001.html">Introduction</a>
-    <ul>
-        <li><a href="sd012.html">Sample Styling Guide</a>
-        </li>
-    </ul>
-    </li>
-    <li><a href="sd002.html">A Section</a>
-    <ul>
-        <li><a href="sd003.html">A Sub-Section</a></li>
-    </ul>
-    </li>
-    <li><a href="sd005.html">A Section</a>
-    <ul>
-        <li><a href="sd005.html#first-section">Page First Section</a></li>
-        <li><a href="sd005.html#second-section">Page Second Section</a></li>
-    </ul>
-    </li>
-</ul>
-</nav>
-</body></html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title></title>
+    </head>
+    <body>
+        <nav id="docet-menu">
+            <ul>
+                <li><a href="sd001.html">Introduction</a>
+                    <ul>
+                        <li><a href="sd012.html">Sample Styling Guide</a></li>
+                    </ul>
+                </li>
+                <li>
+                    <a href="sd002.html">A Section</a>
+                    <ul>
+                        <li><a href="sd003.html">A Sub-Section</a></li>
+                    </ul>
+                </li>
+                <li>
+                    <a href="sd005.html">A Section</a>
+                    <ul>
+                        <li><a href="sd005.html#first-section">Page First Section</a></li>
+                        <li><a href="sd005.html#second-section">Page Second Section</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </nav>
+    </body>
+</html>

--- a/docet-sample-doc/src/main/docs/it/pages/hidden.html
+++ b/docet-sample-doc/src/main/docs/it/pages/hidden.html
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
+        <meta name="docet-hidden-page" >
+    </head>
+    <body>
+        <div id="main">
+            <h1>Pagina Nascosta</h1>
+            <p id="abstract">
+                Questa pagina non è collegata nella tabella dei contanuti e può solo essere visitata dal link di riferimento.
+            </p>
+        </div>
+    </body>
+</html>

--- a/docet-sample-doc/src/main/docs/it/pages/main.html
+++ b/docet-sample-doc/src/main/docs/it/pages/main.html
@@ -1,8 +1,6 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta  />
-	
 </head>
 <body><div id="main">
 <h1>Sample Documentation Package</h1>

--- a/docet-sample-doc/src/main/docs/it/pages/main.html
+++ b/docet-sample-doc/src/main/docs/it/pages/main.html
@@ -1,6 +1,7 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta  />
 	
 </head>
 <body><div id="main">

--- a/docet-sample-doc/src/main/docs/it/pages/sample.html
+++ b/docet-sample-doc/src/main/docs/it/pages/sample.html
@@ -1,9 +1,16 @@
 <html>
-<head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-</head>
-<body><div id="main">
-<h1>Sample Style Document</h1>
-<p id="abstract">This section provides a very simple example styling guide.</p>
-<p>A styling guide is essential in order to start writing down a guide. Whether you adopt your own style or customize the one presented here, it is fundamental to get acquainted with docet source language</p>
-</div></body></html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    </head>
+    <body>
+        <div id="main">
+            <h1>Sample Style Document</h1>
+            <p id="abstract">
+                This section provides a very simple example styling guide.
+            </p>
+            <p>
+                A styling guide is essential in order to start writing down a guide. Whether you adopt your own style or customize the one presented here, it is fundamental to get acquainted with docet source language
+            </p>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
In this pull request I introduced a meta tag
```
<meta name="docet-hidden-page" >
```
To skip the TOC unlinked file validation.
Writing the head tag with inside this meta you can still pass the validation of the documentation page.