### PR TITLE
Add support for saving current page id

### DIFF
--- a/docet-core/src/main/java/docet/model/DocetPackageInfo.java
+++ b/docet-core/src/main/java/docet/model/DocetPackageInfo.java
@@ -29,7 +29,7 @@ public class DocetPackageInfo {
     private final String packageId;
     private final Path packageDocsDir;
     private final Path packageSearchIndexDir;
-    private AtomicLong lastSearchTS;
+    private final AtomicLong lastSearchTS;
     private long lastPageLoadedTS;
     private final DocetPackageDescriptor descriptor;
     private final DocetDocumentSearcher searchIndex;


### PR DESCRIPTION
Add new configuration option saveCurrentPage, default is true.

When saveCurrentPage=true at every page change we save in window.location.hash a base64 encoded key.
When you load the page (ctrl-r/f5) if the hash contains a valid reference then we jump directly to that page