### PR TITLE
Fix css rendering on PDF TOC after third level

### DIFF
--- a/docet-core/src/main/java/docet/engine/PDFDocumentHandler.java
+++ b/docet-core/src/main/java/docet/engine/PDFDocumentHandler.java
@@ -765,9 +765,10 @@ public class PDFDocumentHandler {
         builder.append("<ol>");
 
         for(TOCNode node : nodes) {
+            final String levelClass = "l" + Math.min(node.document.getLevel(), 3);
             builder
                 .append("<li>")
-                .append("<table class=\"l").append(node.document.getLevel()).append("\">")
+                .append("<table class=\"").append(levelClass).append("\"\">")
                 .append("<tr>")
                 .append("<td class=\"toc-bullet\">").append(node.bullet).append("</td>")
                 .append("<td>").append(node.document.name).append("</td>")

--- a/docet-core/src/main/java/docet/engine/PDFDocumentHandler.java
+++ b/docet-core/src/main/java/docet/engine/PDFDocumentHandler.java
@@ -768,7 +768,7 @@ public class PDFDocumentHandler {
             final String levelClass = "l" + Math.min(node.document.getLevel(), 3);
             builder
                 .append("<li>")
-                .append("<table class=\"").append(levelClass).append("\"\">")
+                .append("<table class=\"").append(levelClass).append("\">")
                 .append("<tr>")
                 .append("<td class=\"toc-bullet\">").append(node.bullet).append("</td>")
                 .append("<td>").append(node.document.name).append("</td>")


### PR DESCRIPTION
Now after third level (fourth, fifth...) of TOC on generated PDF, we use the same css rules as third level