### PR TITLE
Upgrade Jsoup to 1.15.1. Fixes #77

### DIFF
--- a/docet-core/src/main/java/docet/DocetUtils.java
+++ b/docet-core/src/main/java/docet/DocetUtils.java
@@ -30,13 +30,13 @@ import java.util.logging.Logger;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.jsoup.safety.Whitelist;
 import org.jsoup.select.Elements;
 
 import docet.model.DocetPackageDescriptor;
 import io.netty.util.internal.PlatformDependent;
 import java.util.ArrayList;
 import java.util.List;
+import org.jsoup.safety.Safelist;
 
 
 /**
@@ -139,16 +139,16 @@ public final class DocetUtils {
 
 
     public static String cleanPageText(final String dirtyPageText, boolean enableIframe) {
-        final Whitelist whiteList = Whitelist.relaxed();
+        final Safelist safeList = Safelist.relaxed();
         if (enableIframe) {
-            whiteList.addTags("iframe");
-            whiteList.addAttributes("iframe", "src", "frameborder", "width", "height", "allowfullscreen", "allow");
+            safeList.addTags("iframe");
+            safeList.addAttributes("iframe", "src", "frameborder", "width", "height", "allowfullscreen", "allow");
         }
-        whiteList.addAttributes(":all", "class", "id", "href", "docetref", "title", "package", "src");
-        whiteList.removeProtocols("a", "href", "ftp", "http", "https", "mailto");
-        whiteList.removeProtocols("img", "src", "http", "https");
-        whiteList.preserveRelativeLinks(true);
-        return Jsoup.clean(dirtyPageText, whiteList);//.replaceAll("<img ([^</]+)>", "<img $1 />");
+        safeList.addAttributes(":all", "class", "id", "href", "docetref", "title", "package", "src");
+        safeList.removeProtocols("a", "href", "ftp", "http", "https", "mailto");
+        safeList.removeProtocols("img", "src", "http", "https");
+        safeList.preserveRelativeLinks(true);
+        return Jsoup.clean(dirtyPageText, safeList);//.replaceAll("<img ([^</]+)>", "<img $1 />");
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <libs.jackson.mapper>1.9.11</libs.jackson.mapper>
         <libs.lucene>5.5.4</libs.lucene>
         <libs.commonsio>2.4</libs.commonsio>
-        <libs.jsoup>1.8.3</libs.jsoup>
+        <libs.jsoup>1.15.1</libs.jsoup>
         <libs.junit>4.12</libs.junit>
         <libs.servletapi>3.1.0</libs.servletapi>
         <libs.flyingsaucer.pdf>9.1.7</libs.flyingsaucer.pdf>


### PR DESCRIPTION
Upgrade jsoup to 1.15.1. WhiteList has been replaced with SafeList that is his drop in replacement

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
